### PR TITLE
feat!: Bump Microsoft.Data.SqlClient to 6.1.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    # The test project keeps a net472 leg, which needs MSBuild on Windows.
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore SqlDatabaseBuilder.sln
+
+      # Debug only. The Release configuration strong-name signs against
+      # SqlDatabaseBuilder.snk, which is not in the repository -- the Azure
+      # Pipelines build pulls it in as a secure file.
+      - name: Build
+        run: dotnet build SqlDatabaseBuilder.sln --configuration Debug --no-restore
+
+      # Tests are deliberately not run here. Every fixture under tests/ reads a
+      # connection string from the AzureSqlServerPath environment variable and
+      # talks to a live SQL Server, so there is nothing meaningful to execute
+      # without provisioning a database. This workflow verifies that the
+      # solution restores and compiles.

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,6 +4,6 @@
     <add key="defaultPushSource" value="https://api.nuget.org/v3/index.json" />
   </config>
   <packageSources>
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/src/SqlDatabaseBuilder/SqlDatabaseBuilder.csproj
+++ b/src/SqlDatabaseBuilder/SqlDatabaseBuilder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <PackageId>SqlDatabaseBuilder</PackageId>
     <Authors>Jeff Trimmer,Mauricio Beithia</Authors>
     <Owners>Jeff Trimmer</Owners>
@@ -14,8 +14,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/Xtrimmer/SqlDatabaseBuilder</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <Version>3.1.1</Version>
+    <PackageReleaseNotes>Moves to Microsoft.Data.SqlClient 6.1.6, which clears CVE-2024-0056 and CVE-2022-41064 and drops the System.Runtime.Caching dependency chain that carried a critical System.Drawing.Common advisory. This raises the minimum .NET Framework target from 4.6 to 4.6.2, so projects on net46 or net461 need to move to net462 or later.</PackageReleaseNotes>
+    <Version>4.0.0</Version>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.6" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/SqlDatabaseBuilder/SqlDatabaseBuilder.csproj
+++ b/src/SqlDatabaseBuilder/SqlDatabaseBuilder.csproj
@@ -31,7 +31,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/tests/SqlDatabaseBuilderTests/SqlDatabaseBuilderTests.csproj
+++ b/tests/SqlDatabaseBuilderTests/SqlDatabaseBuilderTests.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

`Microsoft.Data.SqlClient` was pinned at 2.0.0, carrying two Dependabot alerts: CVE-2024-0056 (high, a man in the middle can decrypt TLS traffic) and CVE-2022-41064 (moderate, information disclosure).

The build could not be verified either way. There was no CI, the test project targeted `netcoreapp3.1` whose targeting packs no longer ship with current SDKs, and `NuGet.Config` pointed at the retired nuget.org v2 endpoint that modern clients cannot restore from.

Adding CI then turned up three more advisories that NuGet Audit reports but Dependabot never alerted on, all transitive under SqlClient 2.1.x and all pre-existing under 2.0.0:

- `System.Drawing.Common` 4.7.0, **critical** ([GHSA-rxg9-xrhp-64gj](https://github.com/advisories/GHSA-rxg9-xrhp-64gj)), reached via `System.Runtime.Caching` → `System.Configuration.ConfigurationManager` → `System.Security.Permissions` → `System.Windows.Extensions`
- `System.IdentityModel.Tokens.Jwt` 6.8.0, moderate ([GHSA-59j7-ghrg-fj52](https://github.com/advisories/GHSA-59j7-ghrg-fj52))
- `Microsoft.IdentityModel.JsonWebTokens` 6.8.0, same advisory

## Solution

Go to `Microsoft.Data.SqlClient` 6.1.6 rather than the 2.1.7 Dependabot proposed. 6.x removes the cause of the transitive findings instead of pinning around them: it replaced `System.Runtime.Caching` with `Microsoft.Extensions.Caching.Memory`, so the `System.Drawing.Common` chain is gone entirely, and it requires the IdentityModel packages at 7.7.1. The build now reports no vulnerability warnings at all.

Only `SqlConnection` and `SqlCommand` are used from SqlClient, both unchanged, so there are no source edits.

Retarget the test project to `net472;net10.0` and update the test packages. `net46` could not stay there regardless: `Microsoft.NET.Test.Sdk` 18.x needs `net462` or later and `xunit.runner.visualstudio` 3.x needs `net472`.

Point `NuGet.Config` at the v3 endpoint and add a GitHub Actions workflow that restores and builds on `windows-latest`. It builds `Debug` only, since `Release` strong-name signs against a `SqlDatabaseBuilder.snk` that lives in Azure DevOps rather than the repo. It does not run tests: every fixture under `tests/` reads a connection string from `AzureSqlServerPath` and talks to a live SQL Server.

## Breaking change

The minimum .NET Framework target moves from `net46` to `net462`, because `net462` is the oldest Framework target SqlClient 6.x ships. .NET Framework support is retained, just not for 4.6 and 4.6.1, both of which left Microsoft support in April 2022. Consumers on `net461` and up already resolved against the `netstandard2.0` asset. Package version goes to 4.0.0.

Note that 6.x also widens the library dependency footprint, pulling in `Azure.Identity`, `Azure.Core` and `Microsoft.Extensions.Caching.Memory`. That is inherent to modern SqlClient.